### PR TITLE
Add Django 2.2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        django-version: ["<3.0", ">=3.0"]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install django djangorestframework injector pytest pytest-cov pytest-flake8
+        pip install "django${{ matrix.django-version }}" djangorestframework injector pytest pytest-cov pytest-flake8
     - name: Test with pytest
       run: |
         PYTHONPATH=. pytest

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Injector is a dependency-injection framework for Python, inspired by Guice. You 
 [Injector documentation on Read the Docs](https://injector.readthedocs.io/en/latest/). Django-Injector is
 inspired by [Flask-Injector](https://github.com/alecthomas/flask_injector).
 
-Django-Injector is compatiable with CPython 3.6+, Django 3.0+ and Django Rest Framework 3 (optional).
+Django-Injector is compatiable with CPython 3.6+, Django 2.2+ and Django Rest Framework 3 (optional).
 
 Github page: https://github.com/blubber/django_injector
 

--- a/django_injector/__init__.py
+++ b/django_injector/__init__.py
@@ -9,7 +9,10 @@ import warnings
 from django.apps import AppConfig, apps
 from django.conf import Settings, settings
 from django.core import management
-from django.core.handlers.asgi import ASGIRequest
+try:
+    from django.core.handlers.asgi import ASGIRequest
+except ImportError:
+    ASGIRequest = None
 from django.http import HttpRequest
 from django.template.engine import Engine
 from django.urls import URLPattern, URLResolver, get_resolver
@@ -261,7 +264,7 @@ class DjangoModule(Module):
         self._local = threading.local()
 
     def set_request(self, request: HttpRequest) -> None:
-        if isinstance(request, ASGIRequest):
+        if ASGIRequest and isinstance(request, ASGIRequest):
             if settings.DEBUG:
                 logger.warning(
                     'Calling DjangoModule.set_request with a ASGIRequest will lead to '


### PR DESCRIPTION
It's the only viable LTS branch right now, migrating from 2.2 to 3.x
is not trivial in some cases and it's a very simple change to restore
the compatibility, so I think it's worth having this.