### PR TITLE
Allow injection on setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,11 @@ class MyView(View):
         # Django-Injector. The injection also works on the setup method.
         self.my_service = my_service
 
-class MyAPIView(APIView):
+class MyAPIView(APIView):  # Also works on ViewSet derivatives
     @inject
     def setup(self, request, my_service: MyService, **kwargs):
-        # In Rest Framework views the injection can be done on the __init__
-        # method and the setup method. However, attempting to inject on the __init__
-        # will result in an exception if the HTML renderer is used. If the HTML renderer is
-        # not used injection on __init__ is safe. Injection on ViewSet instances
-        # works in the same way, and the same caveat applies.
+      # Injection on __init__ will result in a TypeError when using the HTML
+      # renderer.
 ```
 
 Context processors have the same signature as view functions and work in the same way. They should

--- a/django_injector/__init__.py
+++ b/django_injector/__init__.py
@@ -119,6 +119,12 @@ def wrap_drf_view_set(fun: Callable, injector: Injector) -> Callable:
         self.args = args
         self.kwargs = kwargs
 
+        injector.call_with_injection(
+            callable=self.setup,
+            args=(request,) + args,
+            kwargs=kwargs,
+        )
+
         # And continue as usual
         return self.dispatch(request, *args, **kwargs)
 
@@ -144,7 +150,11 @@ def wrap_class_based_view(fun: Callable, injector: Injector) -> Callable:
     # to enable injection into class based view constructors.
     def view(request: Any, *args: Any, **kwargs: Any) -> Any:
         self = injector.create_object(cls, additional_kwargs=initkwargs)
-        self.setup(request, *args, **kwargs)
+        injector.call_with_injection(
+            callable=self.setup,
+            args=(request,) + args,
+            kwargs=kwargs,
+        )
         if not hasattr(self, 'request'):
             raise AttributeError(
                 "%s instance has no 'request' attribute. Did you override "


### PR DESCRIPTION
DRFs HTML renderer will instantiate ViewSet instances to render
breadcrumbs, this results in a TypeError as the HTML renderer does not
use injector. By allowing injection on the setup method this is
circumvented.