### PR TITLE
Added compatibility for DRF's .as_view() method

### DIFF
--- a/django_injector/__init__.py
+++ b/django_injector/__init__.py
@@ -171,6 +171,7 @@ def wrap_class_based_view(fun: Callable, injector: Injector) -> Callable:
         # DRF. In addition, DRF views are csrf exempt by default, the SessionAuthentication
         # auth backend will selectively apply CSRF protection.
         cast(Any, view).cls = cls
+        cast(Any, view).initkwargs = initkwargs
         view = csrf_exempt(view)
 
     return view


### PR DESCRIPTION
I had an issue when using `django_injector` with [drf-yasg2](https://github.com/JoelLefkowitz/drf-yasg): the schema was generated only for ViewSets skipping all my DRF's APIView subclasses. The Schema generator (the one, the is built in Django REST Framework) was expecting each DRF view to have `.initkwargs` property, but `django_injector` APIView wrapper (which is actually the replacement) was not setting this property.

Link to DRF source code where it sets the `.initkwargs` property: https://github.com/encode/django-rest-framework/blob/master/rest_framework/views.py#L140