### PR TITLE
Fix typo for middleware configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARES = [
     ...
-    'django_injector.inject_request_middleware',
+    'django_injector.apps.inject_request_middleware',
 ]
 ```
 


### PR DESCRIPTION
The README mentions the wrong module for the middleware that you need for injector to work.